### PR TITLE
Added a command to check if a word is phonotactically valid in Na'vi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 )
 
 //for testing on a local machine's fwew-lib
-//replace github.com/fwew/fwew-lib/v5 => ../fwew-lib
+replace github.com/fwew/fwew-lib/v5 => ../fwew-lib

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 )
 
 //for testing on a local machine's fwew-lib
-replace github.com/fwew/fwew-lib/v5 => ../fwew-lib
+//replace github.com/fwew/fwew-lib/v5 => ../fwew-lib

--- a/main.go
+++ b/main.go
@@ -474,6 +474,11 @@ func getReefFromIpa(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(fwew.ReefMe(vars["i"], false))
 }
 
+func getValidity(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	json.NewEncoder(w).Encode(fwew.IsValidNavi(vars["i"]))
+}
+
 // set the Header Content-Type to "application/json" for all endpoints
 func contentTypeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -514,6 +519,7 @@ func handleRequests() {
 	myRouter.HandleFunc("/api/multi-ipa", getMultiIPA)
 	myRouter.HandleFunc("/api/total-words", getDictLen)
 	myRouter.HandleFunc("/api/reef/{i}", getReefFromIpa)
+	myRouter.HandleFunc("/api/valid/{i}", getValidity)
 
 	log.Fatal(http.ListenAndServe(":"+config.Port, myRouter))
 }

--- a/main.go
+++ b/main.go
@@ -84,9 +84,11 @@ func getEndpoints(w http.ResponseWriter, r *http.Request) {
 	"name_full_url": "ROOT/name/full/{ending}/{n}/{s1}/{s2}/{s3}/{dialect}",
 	"name_alu_url": "ROOT/name/alu/{n}/{s}/{nm}/{am}/{dialect}",
 	"homonyms_url": "ROOT/homonyms",
+	"oddballs_url": "ROOT/oddballs",
 	"multi_ipa_url": "ROOT/multi-ipa",
 	"dict-len-url": "ROOT/total-words",
-	"reef-ipa-url": "ROOT/reef/{i}"
+	"reef-ipa-url": "ROOT/reef/{i}",
+	"validity-url": "ROOT/valid/{i}"
 }`
 	endpointsJSON = strings.ReplaceAll(endpointsJSON, "ROOT", config.WebRoot)
 	endpointsJSON = strings.ReplaceAll(endpointsJSON, " ", "")

--- a/main.go
+++ b/main.go
@@ -459,6 +459,11 @@ func getHomonyms(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(a)
 }
 
+func getOddballs(w http.ResponseWriter, r *http.Request) {
+	a, _ := fwew.GetOddballs()
+	json.NewEncoder(w).Encode(a)
+}
+
 func getMultiIPA(w http.ResponseWriter, r *http.Request) {
 	a, _ := fwew.GetMultiIPA()
 	json.NewEncoder(w).Encode(a)
@@ -516,6 +521,7 @@ func handleRequests() {
 	myRouter.HandleFunc("/api/phonemedistros", getPhonemeDistros)
 	myRouter.HandleFunc("/api/multiwordwords", getMultiwordWords)
 	myRouter.HandleFunc("/api/homonyms", getHomonyms)
+	myRouter.HandleFunc("/api/oddballs", getOddballs)
 	myRouter.HandleFunc("/api/multi-ipa", getMultiIPA)
 	myRouter.HandleFunc("/api/total-words", getDictLen)
 	myRouter.HandleFunc("/api/reef/{i}", getReefFromIpa)


### PR DESCRIPTION
- Added a `/valid` command to determine whether or not a word would be valid as a Na'vi word, including whether or not it looks like a reef dialect word and what is wrong with the word (if anything)
- Added an `/oddball` command to show all (3 of) the Na'vi words that seemingly violate Na'vi phonotactics (jakesully, oìsss, oìsss si)